### PR TITLE
Fix the accepted normalization strings 

### DIFF
--- a/hendrics/fspec.py
+++ b/hendrics/fspec.py
@@ -231,9 +231,6 @@ def calc_fspec(files, fftlen,
     [5] Miyamoto et al. 1991, ApJ, 383, 784
 
     """
-    if normalization.lower() not in ['leahy', 'rms']:
-        logging.warning('Beware! Unknown normalization!')
-        normalization = 'leahy'
 
     logging.info('Using %s normalization' % normalization)
 
@@ -459,6 +456,11 @@ def main(args=None):
     fftlen = args.fftlen
     pdsrebin = args.rebin
     normalization = args.norm
+    if normalization.lower() not in ["frac", "abs", "leahy", "none", "rms"]:
+        warnings.warn('Beware! Unknown normalization!')
+        normalization = 'leahy'
+    if normalization == 'rms':
+        normalization = 'frac'
 
     do_cpds = do_pds = do_cos = do_lag = False
     kinds = args.kind.split(',')

--- a/hendrics/tests/test_fullrun.py
+++ b/hendrics/tests/test_fullrun.py
@@ -460,6 +460,19 @@ class TestFullRun(object):
         assert np.allclose(gti_to_test, out_lc.gti)
 
 
+    def test_pds_leahy(self):
+        """Test PDS production."""
+        lc = os.path.join(self.datadir, 'monol_testA_E3-50_lc') + \
+                HEN_FILE_EXTENSION
+        hen.io.main([lc])
+        command = \
+            '{0} -f 128 -k PDS --norm leahy'.format(lc)
+        hen.fspec.main(command.split())
+
+        assert os.path.exists(os.path.join(self.datadir,
+                                           'monol_testA_E3-50_pds')
+                              + HEN_FILE_EXTENSION)
+
     def test_pds(self):
         """Test PDS production."""
         command = \
@@ -492,6 +505,33 @@ class TestFullRun(object):
                                   HEN_FILE_EXTENSION)
         command = '{0} -f 128'.format(lcurve_txt)
         hen.fspec.main(command.split())
+
+    def test_cpds_rms_norm(self):
+        """Test CPDS production."""
+        command = \
+            '{0} {1} -f 128 --save-dyn -k CPDS --norm rms -o {2}'.format(
+                os.path.join(self.datadir, 'monol_testA_E3-50_lc') +
+                HEN_FILE_EXTENSION,
+                os.path.join(self.datadir, 'monol_testB_E3-50_lc') +
+                HEN_FILE_EXTENSION,
+                os.path.join(self.datadir, 'monol_test_E3-50'))
+
+        hen.fspec.main(command.split())
+
+    def test_cpds_wrong_norm(self):
+        """Test CPDS production."""
+        command = \
+            '{0} {1} -f 128 --save-dyn -k CPDS --norm blablabla -o {2}'.format(
+                os.path.join(self.datadir, 'monol_testA_E3-50_lc') +
+                HEN_FILE_EXTENSION,
+                os.path.join(self.datadir, 'monol_testB_E3-50_lc') +
+                HEN_FILE_EXTENSION,
+                os.path.join(self.datadir, 'monol_test_E3-50'))
+        with pytest.warns(UserWarning) as record:
+            hen.fspec.main(command.split())
+
+        assert np.any(["Beware! Unknown normalization" in r.message.args[0]
+                       for r in record])
 
     def test_cpds(self):
         """Test CPDS production."""


### PR DESCRIPTION
Fix the accepted normalizations to adapt to Stingray's names
`leahy, rms` -> `leahy, frac, none, abs, rms`
`rms` remains as a synonym of `frac`, to avoid confusing MaLTPyNT users!

Tests will probably fail for this Issue with `safe-interval`: https://github.com/StingraySoftware/stingray/pull/283
