### PR TITLE
Use faster z

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,13 +46,14 @@ matrix:
         # Old matplotlib
         - env: PYTHON_VERSION=3.7 SETUP_CMD='test --coverage' USE_NETCDF=no
         - os: windows
-          env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage' USE_NUMBA=yes PIP_DEPENDENCIES='scipy matplotlib pip pandas emcee stingray>=0.1rc1 ' CONDA_DEPENDENCIES=''
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage' USE_NUMBA=yes PIP_DEPENDENCIES='fast-histogram scipy matplotlib pip pandas emcee stingray>=0.1rc1 ' CONDA_DEPENDENCIES=''
         - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage' USE_NUMBA=yes
+        - env: PYTHON_VERSION=3.7 SETUP_CMD='test --coverage' USE_NUMBA=yes PIP_DEPENDENCIES='fast-histogram emcee stingray>=0.1rc1 '
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - env: PYTHON_VERSION=3.6 SETUP_CMD='build_docs -w' PIP_DEPENDENCIES='sphinx-astropy emcee stingray>=0.1rc1'
         - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage --remote-data' USE_NUMBA=yes PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem stingray'
-        - env: PYTHON_VERSION=3.7 SETUP_CMD='test --coverage --remote-data' USE_NUMBA=yes PIP_DEPENDENCIES='git+https://git@github.com/nanograv/pint.git jplephem stingray'
+        - env: PYTHON_VERSION=3.7 SETUP_CMD='test --coverage --remote-data' USE_NUMBA=yes PIP_DEPENDENCIES='fast-histogram git+https://git@github.com/nanograv/pint.git jplephem stingray'
 
         # ----- Try risky stuff ----
         - env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage' USE_NUMBA=yes STINGRAY_VERSION=devel

--- a/hendrics/base.py
+++ b/hendrics/base.py
@@ -260,8 +260,7 @@ def deorbit_events(events, parameter_file=None):
     if parameter_file is None:
         return events
     elif not os.path.exists(parameter_file):
-        warnings.warn("Parameter file {} does not exist".format(parameter_file))
-        return events
+        raise FileNotFoundError("Parameter file {} does not exist".format(parameter_file))
 
     pepoch = events.gti[0, 0]
     pepoch_mjd = pepoch / 86400 + events.mjdref

--- a/hendrics/efsearch.py
+++ b/hendrics/efsearch.py
@@ -260,8 +260,6 @@ def search_with_qffa_step(times, mean_f, mean_fdot=0, nbin=16, nprof=64,
     ts = times - np.mean(times)
     phases = ts * mean_f + 0.5 * ts**2 * mean_fdot
     phases = phases - np.floor(phases)
-    #phbins = np.linspace(0, 1, nbin + 1)
-    #tbins = np.linspace(times[0], times[-1], nprof + 1)
     profiles = histogram2d(phases, times, range=[[0, 1], [times[0], times[-1]]],
                             bins=(nbin, nprof))
     t0, t1 = times.min(), times.max()

--- a/hendrics/efsearch.py
+++ b/hendrics/efsearch.py
@@ -23,7 +23,7 @@ try:
     from fast_histogram import histogram2d
     HAS_FAST_HIST = True
 except ImportError:
-    from numpy import histogram2d_np
+    from numpy import histogram2d as histogram2d_np
     def histogram2d(*args, **kwargs):
         return histogram2d_np(*args, **kwargs)[0]
 
@@ -276,7 +276,6 @@ def search_with_qffa_step(times, mean_f, mean_fdot=0, nbin=16, nprof=64,
     #tbins = np.linspace(times[0], times[-1], nprof + 1)
     profiles = histogram2d(phases, times, range=[[0, 1], [times[0], times[-1]]],
                             bins=(nbin, nprof))
-    print(profiles)
     t0, t1 = times.min(), times.max()
 
     # dn = max(1, int(nbin / oversample))
@@ -338,7 +337,8 @@ def search_with_qffa_step_old(times, mean_f, mean_fdot=0, nbin=16, nprof=64,
     twopiphases = 2 * np.pi * np.arange(0, 1, 1/nbin)
     for i, l in enumerate(linbinshifts):
         for j, q in enumerate(quabinshifts):
-            newprof = shift_and_select_parallel(repeated_profiles, L[i, j], Q[i, j],
+            newprof = shift_and_select_parallel(repeated_profiles, L[i, j],
+                                                Q[i, j],
                                        newprof)
             splat_prof = np.sum(newprof, axis=0)
             local_stat = z_n_fast(twopiphases, norm=splat_prof, n=n)

--- a/hendrics/efsearch.py
+++ b/hendrics/efsearch.py
@@ -18,6 +18,15 @@ import os
 import logging
 import argparse
 from functools import wraps
+
+try:
+    from fast_histogram import histogram2d
+    HAS_FAST_HIST = True
+except ImportError:
+    from numpy import histogram2d_np
+    def histogram2d(*args, **kwargs):
+        return histogram2d_np(*args, **kwargs)[0]
+
 try:
     from numba import njit, prange
 except:
@@ -169,7 +178,7 @@ def calculate_shifts(nprof: int, nbin : int, nshift : int, order : int =1) -> np
     return nshift * shifts
 
 
-@njit(parallel=True)
+@njit()
 def shift_and_select(repeated_profiles, lshift, qshift, newprof):
     nprof = len(repeated_profiles)
     nbin = len(newprof[0])
@@ -181,7 +190,19 @@ def shift_and_select(repeated_profiles, lshift, qshift, newprof):
     return newprof
 
 
-@njit()
+@njit(parallel=True)
+def shift_and_select_parallel(repeated_profiles, lshift, qshift, newprof):
+    nprof = len(repeated_profiles)
+    nbin = len(newprof[0])
+    lshifts = calculate_shifts(nprof, nbin, lshift, 1)
+    qshifts = calculate_shifts(nprof, nbin, qshift, 2)
+    for k in prange(nprof):
+        total_shift = int(np.rint(lshifts[k] + qshifts[k])) % nbin
+        newprof[k, :] = repeated_profiles[k, nbin - total_shift: 2 * nbin - total_shift]
+    return newprof
+
+
+@njit(fastmath=True)
 def z_n_fast(phase, norm, n=2):
     '''Z^2_n statistics, a` la Buccheri+03, A&A, 128, 245, eq. 2.
 
@@ -215,14 +236,71 @@ def z_n_fast(phase, norm, n=2):
     total_norm = np.sum(norm)
 
     result = 0
+    # Instead of calculating k phi each time
+    kph = np.zeros_like(phase)
+
     for k in range(1, n + 1):
-        kph = k * phase
+        kph += phase
         result += np.sum(np.cos(kph) * norm) ** 2 + np.sum(np.sin(kph) * norm) ** 2
 
     return 2 / total_norm * result
 
 
+@njit(parallel=True)
+def _fast_step(profiles, L, Q, linbinshifts, quabinshifts, nbin, n=2):
+    twopiphases = 2 * np.pi * np.arange(0, 1, 1/nbin)
+    stats = np.zeros_like(L)
+    profiles = profiles.T
+    newprof = np.zeros_like(profiles)
+    repeated_profiles = np.hstack((profiles, profiles, profiles))
+
+    for i in range(len(linbinshifts)):
+        for j in range(len(quabinshifts)):
+            newprof = shift_and_select(repeated_profiles, L[i, j], Q[i, j],
+                                       newprof)
+            splat_prof = np.sum(newprof, axis=0)
+            local_stat = z_n_fast(twopiphases, norm=splat_prof, n=n)
+            # local_stat = stat(splat_prof)
+            stats[i, j] = local_stat
+
+    return stats
+
+
 def search_with_qffa_step(times, mean_f, mean_fdot=0, nbin=16, nprof=64,
+                          npfact=2, oversample=8, n=1, search_fdot=True):
+    """Single step of quasi-fast folding algorithm."""
+    ts = times - np.mean(times)
+    phases = ts * mean_f + 0.5 * ts**2 * mean_fdot
+    phases = phases - np.floor(phases)
+    #phbins = np.linspace(0, 1, nbin + 1)
+    #tbins = np.linspace(times[0], times[-1], nprof + 1)
+    profiles = histogram2d(phases, times, range=[[0, 1], [times[0], times[-1]]],
+                            bins=(nbin, nprof))
+    print(profiles)
+    t0, t1 = times.min(), times.max()
+
+    # dn = max(1, int(nbin / oversample))
+    linbinshifts = np.linspace(-nbin * npfact, nbin * npfact, oversample * npfact)
+    if search_fdot:
+        quabinshifts = np.linspace(-nbin * npfact, nbin * npfact, oversample * npfact)
+    else:
+        quabinshifts = [0]
+
+    dphi = 1 / nbin
+    delta_t = (t1 - t0) / 2
+    df = dphi / delta_t
+    dfdot = 2 * dphi / delta_t ** 2
+
+    bin_to_frequency = df
+    bin_to_fdot = dfdot
+    L, Q = np.meshgrid(linbinshifts, quabinshifts, indexing='ij')
+
+    stats = _fast_step(profiles, L, Q, linbinshifts, quabinshifts, nbin, n=n)
+
+    return L * bin_to_frequency + mean_f, Q * bin_to_fdot + mean_fdot, stats
+
+
+def search_with_qffa_step_old(times, mean_f, mean_fdot=0, nbin=16, nprof=64,
                           npfact=2, oversample=8, n=1, search_fdot=True):
     """Single step of quasi-fast folding algorithm."""
     ts = times - np.mean(times)
@@ -252,8 +330,6 @@ def search_with_qffa_step(times, mean_f, mean_fdot=0, nbin=16, nprof=64,
     bin_to_frequency = df
     bin_to_fdot = dfdot
 
-    factor = bin_to_frequency
-
     stats = np.zeros_like(L)
     profiles = profiles.T
     newprof = np.zeros_like(profiles)
@@ -262,7 +338,7 @@ def search_with_qffa_step(times, mean_f, mean_fdot=0, nbin=16, nprof=64,
     twopiphases = 2 * np.pi * np.arange(0, 1, 1/nbin)
     for i, l in enumerate(linbinshifts):
         for j, q in enumerate(quabinshifts):
-            newprof = shift_and_select(repeated_profiles, L[i, j], Q[i, j],
+            newprof = shift_and_select_parallel(repeated_profiles, L[i, j], Q[i, j],
                                        newprof)
             splat_prof = np.sum(newprof, axis=0)
             local_stat = z_n_fast(twopiphases, norm=splat_prof, n=n)

--- a/hendrics/tests/test_efsearch.py
+++ b/hendrics/tests/test_efsearch.py
@@ -19,6 +19,17 @@ except:
 from hendrics.fold import HAS_PINT
 
 
+def _dummy_par(par):
+    with open(par, 'a') as fobj:
+        print("BINARY BT", file=fobj)
+        print("PB  1e20", file=fobj)
+        print("A1  0", file=fobj)
+        print("T0  56000", file=fobj)
+        print("EPHEM  DE200", file=fobj)
+        print("RAJ  00:55:01", file=fobj)
+        print("DECJ 12:00:40.2", file=fobj)
+
+
 class TestEFsearch():
     def setup_class(cls):
         cls.pulse_frequency = 1/0.101
@@ -163,14 +174,8 @@ class TestEFsearch():
     def test_efsearch_deorbit(self):
         evfile = self.dum
         par = 'bububububu.par'
-        with open (par, 'a') as fobj:
-            print("BINARY BT", file=fobj)
-            print("PB  1e20", file=fobj)
-            print("A1  0", file=fobj)
-            print("T0  56000", file=fobj)
-            print("EPHEM  DE200", file=fobj)
-            print("RAJ  00:55:01", file=fobj)
-            print("DECJ 12:00:40.2", file=fobj)
+
+        _dummy_par(par)
 
         ip = main_zsearch([evfile, '-f', '9.85', '-F', '9.95', '-n', '64',
                            '--deorbit-par', par])
@@ -178,20 +183,14 @@ class TestEFsearch():
         outfile = 'events_Z2n' + HEN_FILE_EXTENSION
         assert os.path.exists(outfile)
         plot_folding([outfile], ylog=True)
+        os.unlink(par)
 
     def test_efsearch_deorbit_invalid(self):
         evfile = self.dum
-        with pytest.warns(UserWarning) as record:
+        with pytest.raises(FileNotFoundError) as excinfo:
             ip = main_efsearch([evfile, '-f', '9.85', '-F', '9.95', '-n', '64',
                                '--deorbit-par', "nonexistent.par"])
-        assert np.any(["Parameter file" in r.message.args[0] for r in record])
-
-        outfile = 'events_EF' + HEN_FILE_EXTENSION
-        assert os.path.exists(outfile)
-        with pytest.warns(UserWarning) as record:
-            plot_folding([outfile], ylog=True)
-        assert np.any(["does not exist" in r.message.args[0] for r in record])
-
+        assert "Parameter file" in str(excinfo.value)
 
     @classmethod
     def teardown_class(cls):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ astropy
 matplotlib
 stingray >= 0.1rc1
 sphinx-astropy
+fast-histogram
 


### PR DESCRIPTION
Use more aggressive optimization in Z search steps (all in `hendrics.efsearch`):

1. Use a less general but numba-compiled implementation of the Zn statistics (`z_n_fast`)
2. Compile with `numba` the core operations of `search_with_qffa_step` into the new function `_fast_step`
3. Allow the use of the 2d-histogram from [fast-histogram](https://github.com/astrofrog/fast-histogram), which is much faster than `numpy.histogram2d`
4. Move the parallelization from `shift_and_select` to `_fast_step` (so that _more_ code is parallelized!)
