### PR TITLE
Identifying Lightcurve inputs in HENreadevents, and modifying the user warning.

### DIFF
--- a/hendrics/io.py
+++ b/hendrics/io.py
@@ -522,6 +522,27 @@ def get_file_type(fname, raw_data=False):
     return ftype, contents
 
 
+def is_lightcurve(hdulist):
+    """Determine whether the file is a lightcurve
+    
+    Returns:
+    bool: True if the HDU list represents a light curve, False otherwise.
+    """
+    if len(hdulist) < 2:
+        return False
+
+    data_hdu = hdulist[1]
+    if not hasattr(data_hdu, "columns"):
+        return False
+
+    colnames = [col.name.upper() for col in data_hdu.columns]
+
+    time_col = "TIME" in colnames
+    lc_like_col = any(x in colnames for x in ["FLUX", "RATE", "COUNTS", "SAP_FLUX", "PDCSAP_FLUX"])
+
+    return time_col and lc_like_col
+
+
 # ----- functions to save and load EVENT data
 def save_events(eventlist, fname):
     """Save events in a file.

--- a/hendrics/read_events.py
+++ b/hendrics/read_events.py
@@ -16,9 +16,10 @@ from stingray.gti import (
 )
 
 from astropy import log
+from astropy.io import fits
 
 from .base import common_name, hen_root
-from .io import HEN_FILE_EXTENSION, load_events, save_events
+from .io import HEN_FILE_EXTENSION, load_events, save_events, is_lightcurve
 
 
 def treat_event_file(

--- a/hendrics/read_events.py
+++ b/hendrics/read_events.py
@@ -643,6 +643,16 @@ def main(args=None):
 
         arglist = [[f, argdict] for f in files]
 
+        for fname in files:
+            if fname.endswith(".fits") or fname.endswith(".fit"):
+                with fits.open(fname) as hdulist:
+                    hdu_names = [h.name.upper() for h in hdulist]
+                    if "EVENTS" not in hdu_names and is_lightcurve(hdulist):
+                        print(f"\n  The file '{fname}' appears to be a light curve.")
+                        ans = input("Do you want to proceed with reading the file? [y/N]: ").strip().lower()
+                        if ans != 'y':
+                           raise ValueError("Aborted reading.")
+
         if os.name == "nt" or args.nproc == 1:
             [_wrap_fun(a) for a in arglist]
         else:


### PR DESCRIPTION
Fixes issue #129 

**Description:**
       This enhancement ensures that, if user inputs a Lightcurve, it will first identify, it is a lightcurve, and will notify the user about it, further, it will ask the user, whether or not to proceed, as shown in the attached image. Depending on the chosen option, the file reading or aborting the process will be done.

**Current Behavior**
> At the moment, HENreadevents reads a FITS light curve with just a mild warning. It should realize if it is a light curve, and give a stronger warning or just fail.

**Enhanced Behavior**
![Screenshot from 2025-04-16 23-49-22](https://github.com/user-attachments/assets/6233d517-9321-4f89-a18e-dca62879696c)
