### PR TITLE
Replace Astropy logging with standard Python logging.

### DIFF
--- a/hendrics/base.py
+++ b/hendrics/base.py
@@ -27,7 +27,8 @@ from stingray.stats import (
     z2_n_probability,
 )
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.io.registry import identify_format
 from astropy.table import Table
 

--- a/hendrics/binary.py
+++ b/hendrics/binary.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.coordinates import SkyCoord
 
 from .base import deorbit_events, interpret_bintime

--- a/hendrics/calibrate.py
+++ b/hendrics/calibrate.py
@@ -6,7 +6,8 @@ import warnings
 
 import numpy as np
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import get_file_extension
 from .io import HEN_FILE_EXTENSION, load_events, save_events

--- a/hendrics/colors.py
+++ b/hendrics/colors.py
@@ -4,7 +4,8 @@
 import numpy as np
 from stingray.lightcurve import Lightcurve
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import hen_root
 from .io import HEN_FILE_EXTENSION, load_events, save_lcurve

--- a/hendrics/create_gti.py
+++ b/hendrics/create_gti.py
@@ -10,7 +10,8 @@ from stingray.gti import (
     cross_gtis,
 )
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.logger import AstropyUserWarning
 
 from .base import _assign_value_if_none, hen_root

--- a/hendrics/efsearch.py
+++ b/hendrics/efsearch.py
@@ -23,7 +23,8 @@ from stingray.stats import (
 )
 from stingray.utils import assign_value_if_none
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.logger import AstropyUserWarning
 from astropy.table import Table
 from astropy.utils.introspection import minversion

--- a/hendrics/exposure.py
+++ b/hendrics/exposure.py
@@ -12,7 +12,8 @@ from stingray.gti import create_gti_mask
 from stingray.io import load_events_and_gtis
 from stingray.lightcurve import Lightcurve
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import _assign_value_if_none, hen_root
 from .io import HEN_FILE_EXTENSION, get_file_type, save_lcurve

--- a/hendrics/exvar.py
+++ b/hendrics/exvar.py
@@ -5,7 +5,8 @@
 
 from stingray.utils import excess_variance
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import hen_root
 from .io import load_lcurve, save_as_qdp

--- a/hendrics/fake.py
+++ b/hendrics/fake.py
@@ -12,7 +12,8 @@ from stingray.io import get_key_from_mission_info, read_mission_info
 from stingray.lightcurve import Lightcurve
 from stingray.utils import assign_value_if_none
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.io.fits import Header
 
 from .base import deorbit_events, get_file_format, r_in

--- a/hendrics/fold.py
+++ b/hendrics/fold.py
@@ -12,7 +12,8 @@ from scipy.signal import savgol_filter
 from stingray.pulse.pulsar import fold_events, htest, pulse_phase
 from stingray.utils import assign_value_if_none, fft, fftfreq, ifft
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.stats import poisson_conf_interval
 
 from .base import hen_root, normalize_dyn_profile

--- a/hendrics/fspec.py
+++ b/hendrics/fspec.py
@@ -13,7 +13,8 @@ from stingray.lombscargle import LombScargleCrossspectrum, LombScarglePowerspect
 from stingray.powerspectrum import AveragedPowerspectrum
 from stingray.utils import show_progress
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.logger import AstropyUserWarning
 
 from .base import (

--- a/hendrics/io.py
+++ b/hendrics/io.py
@@ -25,7 +25,8 @@ from stingray.pulse.modeling import SincSquareModel
 from stingray.pulse.search import search_best_peaks
 from stingray.utils import assign_value_if_none
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.logger import AstropyUserWarning
 from astropy.modeling.core import Model
 from astropy.table import Table

--- a/hendrics/lcurve.py
+++ b/hendrics/lcurve.py
@@ -10,7 +10,8 @@ from stingray.gti import contiguous_regions, create_gti_mask, cross_gtis
 from stingray.lightcurve import Lightcurve
 from stingray.utils import assign_value_if_none
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.logger import AstropyUserWarning
 
 from .base import (

--- a/hendrics/modeling.py
+++ b/hendrics/modeling.py
@@ -4,7 +4,8 @@ import os
 import numpy as np
 from stingray.modeling import fit_powerspectrum
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .io import HEN_FILE_EXTENSION, load_model, load_pds, save_model, save_pds
 

--- a/hendrics/phaseogram.py
+++ b/hendrics/phaseogram.py
@@ -13,7 +13,8 @@ from scipy.interpolate import interp1d
 from stingray.pulse.search import phaseogram
 from stingray.utils import assign_value_if_none
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.logger import AstropyUserWarning
 from astropy.stats import poisson_conf_interval
 

--- a/hendrics/phasetag.py
+++ b/hendrics/phasetag.py
@@ -7,7 +7,8 @@ from stingray.io import load_events_and_gtis, ref_mjd
 from stingray.pulse.pulsar import phase_exposure, pulse_phase
 
 import astropy.io.fits as pf
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.logger import AstropyUserWarning
 
 from .base import _assign_value_if_none, hen_root, splitext_improved

--- a/hendrics/plot.py
+++ b/hendrics/plot.py
@@ -11,7 +11,8 @@ import numpy as np
 from stingray.gti import create_gti_mask
 from stingray.power_colors import plot_hues, plot_power_colors
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.modeling import Model
 from astropy.modeling.models import Const1D
 from astropy.stats import poisson_conf_interval

--- a/hendrics/power_colors.py
+++ b/hendrics/power_colors.py
@@ -9,7 +9,8 @@ from stingray import DynamicalCrossspectrum, DynamicalPowerspectrum, StingrayTim
 from stingray.gti import cross_two_gtis
 from stingray.power_colors import hue_from_power_color
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import common_name, hen_root, interpret_bintime
 from .io import HEN_FILE_EXTENSION, load_events, save_timeseries

--- a/hendrics/read_events.py
+++ b/hendrics/read_events.py
@@ -15,7 +15,8 @@ from stingray.gti import (
     cross_two_gtis,
 )
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import common_name, hen_root
 from .io import HEN_FILE_EXTENSION, load_events, save_events

--- a/hendrics/rebin.py
+++ b/hendrics/rebin.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Functions to rebin light curves and frequency spectra."""
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import get_file_extension
 from .io import HEN_FILE_EXTENSION, get_file_type, save_lcurve, save_pds

--- a/hendrics/save_as_xspec.py
+++ b/hendrics/save_as_xspec.py
@@ -5,7 +5,8 @@ import subprocess as sp
 
 import numpy as np
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import get_file_extension
 from .io import get_file_type

--- a/hendrics/sum_fspec.py
+++ b/hendrics/sum_fspec.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Function to sum frequency spectra."""
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import _assign_value_if_none
 from .fspec import average_periodograms

--- a/hendrics/tests/test_a_complete_run.py
+++ b/hendrics/tests/test_a_complete_run.py
@@ -7,7 +7,8 @@ import subprocess as sp
 import numpy as np
 import pytest
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.io.registry import IORegistryError
 from hendrics import (
     base,

--- a/hendrics/tests/test_colors.py
+++ b/hendrics/tests/test_colors.py
@@ -6,7 +6,8 @@ import os
 import numpy as np
 import pytest
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from hendrics import calibrate, colors, io, lcurve, plot, read_events
 from hendrics.tests import _dummy_par
 

--- a/hendrics/tests/test_fake.py
+++ b/hendrics/tests/test_fake.py
@@ -7,7 +7,8 @@ import numpy as np
 import pytest
 from stingray import EventList
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.io import fits
 from hendrics import base, calibrate, fake, io, read_events
 from hendrics.base import HAS_PINT

--- a/hendrics/tests/test_fspec.py
+++ b/hendrics/tests/test_fspec.py
@@ -13,7 +13,8 @@ import pytest
 import stingray
 from stingray import EventList
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from hendrics import (
     base,
     fspec,

--- a/hendrics/tests/test_gti.py
+++ b/hendrics/tests/test_gti.py
@@ -3,7 +3,8 @@
 
 import os
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from hendrics import calibrate, create_gti, io, lcurve, read_events
 from hendrics.tests import _dummy_par
 

--- a/hendrics/tests/test_lc.py
+++ b/hendrics/tests/test_lc.py
@@ -7,7 +7,8 @@ import numpy as np
 import pytest
 from stingray.lightcurve import Lightcurve
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.logger import AstropyUserWarning
 from hendrics import (
     base,

--- a/hendrics/timelags.py
+++ b/hendrics/timelags.py
@@ -1,4 +1,5 @@
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 
 from .base import hen_root
 from .io import load_pds, save_as_qdp

--- a/hendrics/varenergy.py
+++ b/hendrics/varenergy.py
@@ -13,7 +13,8 @@ from stingray.varenergyspectrum import (
 )
 from stingray.varenergyspectrum import VarEnergySpectrum as StingrayVes
 
-from astropy import log
+import logging
+logger = logging.getLogger(__name__)
 from astropy.table import Table
 
 from .base import hen_root, interpret_bintime


### PR DESCRIPTION
Fixes issue #102

This PR aims to eliminate the usage of Astropy logging and implement logging using Python's standard logging library.