### PR TITLE
Fix fast Z2n tutorial command typo

### DIFF
--- a/docs/tutorials/pulsars.rst
+++ b/docs/tutorials/pulsars.rst
@@ -69,7 +69,7 @@ Select this algorithm with the ``--fast`` option on the command line of `HENzsea
 
 ::
 
-    $ HENefsearch -f 9.85 -F 9.95 -n 64 --fast -N 3 mistery_psrA_nustar_fpma_ev.nc
+    $ HENzsearch -f 9.85 -F 9.95 -n 64 --fast -N 3 mistery_psrA_nustar_fpma_ev.nc
 
 Here, we are searching from 9.85 to 9.95 Hz, using 3 harmonics (so, ..math:`Z^2_3`
 stats), pre-binning the pulse profile with 64 bins.


### PR DESCRIPTION
Fix the typo in the pulsar tutorial (https://hendrics.stingray.science/en/latest/tutorials/pulsars.html) so the "Fast Z2n searches"  example actually calls `HENzsearch --fast` instead of `HENefsearch --fast`, which matches the surrounding text. 

No function code changes, just documentation cleanup to keep users from running the `HENefsearch`, where `The fast option is only available for z searches`